### PR TITLE
Phase components with quiz and TTS

### DIFF
--- a/app/story/[slug]/page.tsx
+++ b/app/story/[slug]/page.tsx
@@ -1,6 +1,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { notFound } from "next/navigation";
+import PhaseRenderer, { Phase } from "../../../components/Story/PhaseRenderer";
+import TTSButton from "../../../components/Story/TTSButton";
 
 export const dynamicParams = false;
 
@@ -11,16 +13,6 @@ export async function generateStaticParams() {
   return files.filter(f => f.endsWith(".json")).map(f => ({ slug: f.replace(/\.json$/, "") }));
 }
 
-type Phase =
-  | { type: "hook"; heading: string; body: string }
-  | { type: "orientation"; heading: string; body: string }
-  | { type: "discovery"; heading: string; body: string }
-  | { type: "wow-panel"; heading: string; body: string }
-  | { type: "fact-gems"; items: { sourceId: string; text: string }[] }
-  | { type: "mini-quiz"; items: { q: string; choices: string[]; answer: number }[] }
-  | { type: "imagine"; prompt: string }
-  | { type: "wrap"; keyTakeaways: string[] };
-
 type Story = {
   slug: string; title: string; phases: Phase[]; heroImage?: { file: string; alt: string };
 };
@@ -29,39 +21,49 @@ async function loadStory(slug: string): Promise<Story | null> {
   try {
     const raw = await fs.readFile(path.join(CONTENT_DIR, `${slug}.json`), "utf8");
     return JSON.parse(raw);
-  } catch { return null; }
+  } catch {
+    return null;
+  }
+}
+
+function collectText(phases: Phase[]): string {
+  return phases.map(p => {
+    switch (p.type) {
+      case "hook":
+      case "orientation":
+      case "discovery":
+      case "wow-panel":
+        return `${p.heading} ${p.body}`;
+      case "fact-gems":
+        return p.items.map(it => it.text).join(" ");
+      case "mini-quiz":
+        return p.items.map(it => `${it.q} ${it.choices.join(" ")}`).join(" ");
+      case "imagine":
+        return p.prompt;
+      case "wrap":
+        return p.keyTakeaways.join(" ");
+      default:
+        return "";
+    }
+  }).join(" ");
 }
 
 export default async function StoryPage({ params }: { params: { slug: string } }) {
   const story = await loadStory(params.slug);
   if (!story) return notFound();
+  const fullText = `${story.title} ${collectText(story.phases)}`;
   return (
     <main className="p-6 max-w-3xl mx-auto">
       <h1 className="text-3xl font-bold mb-4">{story.title}</h1>
       {story.heroImage && <img className="rounded mb-6" src={story.heroImage.file} alt={story.heroImage.alt} />}
+      <div className="mb-4"><TTSButton text={fullText} /></div>
       <article className="space-y-6">
-        {story.phases.map((p, i) => <section key={i}><PhaseRenderer phase={p as any} /></section>)}
+        {story.phases.map((p, i) => (
+          <section key={i}>
+            <PhaseRenderer phase={p} />
+          </section>
+        ))}
       </article>
     </main>
   );
-}
-
-function PhaseRenderer({ phase }: { phase: any }) {
-  switch (phase.type) {
-    case "hook":
-    case "orientation":
-    case "discovery":
-    case "wow-panel":
-      return (<><h2 className="text-xl font-semibold mb-1">{phase.heading}</h2><p>{phase.body}</p></>);
-    case "fact-gems":
-      return (<ul className="list-disc pl-6">{phase.items.map((it: any, i: number) => <li key={i}><strong>Did you know?</strong> {it.text}</li>)}</ul>);
-    case "mini-quiz":
-      return (<div><h3 className="font-semibold">Quick Quiz</h3><ol className="list-decimal pl-6">{phase.items.map((q:any, i:number)=><li key={i}>{q.q}</li>)}</ol></div>);
-    case "imagine":
-      return (<div className="italic">Imagine: {phase.prompt}</div>);
-    case "wrap":
-      return (<div><h3 className="font-semibold">Takeaways</h3><ul className="list-disc pl-6">{phase.keyTakeaways.map((k:string,i:number)=><li key={i}>{k}</li>)}</ul></div>);
-    default:
-      return null;
-  }
 }

--- a/components/Phase/Discovery.tsx
+++ b/components/Phase/Discovery.tsx
@@ -1,0 +1,8 @@
+export default function Discovery({ heading, body }: { heading: string; body: string }) {
+  return (
+    <div>
+      <h2 className="text-xl font-semibold mb-1">{heading}</h2>
+      <p>{body}</p>
+    </div>
+  );
+}

--- a/components/Phase/FactGems.tsx
+++ b/components/Phase/FactGems.tsx
@@ -1,0 +1,9 @@
+export default function FactGems({ items }: { items: { sourceId: string; text: string }[] }) {
+  return (
+    <ul className="list-disc pl-6">
+      {items.map((it, i) => (
+        <li key={i}><strong>Did you know?</strong> {it.text}</li>
+      ))}
+    </ul>
+  );
+}

--- a/components/Phase/Hook.tsx
+++ b/components/Phase/Hook.tsx
@@ -1,0 +1,8 @@
+export default function Hook({ heading, body }: { heading: string; body: string }) {
+  return (
+    <div>
+      <h2 className="text-xl font-semibold mb-1">{heading}</h2>
+      <p>{body}</p>
+    </div>
+  );
+}

--- a/components/Phase/Imagine.tsx
+++ b/components/Phase/Imagine.tsx
@@ -1,0 +1,3 @@
+export default function Imagine({ prompt }: { prompt: string }) {
+  return <p className="italic">{prompt}</p>;
+}

--- a/components/Phase/MiniQuiz.tsx
+++ b/components/Phase/MiniQuiz.tsx
@@ -1,0 +1,41 @@
+"use client";
+import { useState } from "react";
+
+type QuizItem = { q: string; choices: string[]; answer: number };
+
+export default function MiniQuiz({ items }: { items: QuizItem[] }) {
+  const [selected, setSelected] = useState<number[]>(Array(items.length).fill(-1));
+  const [submitted, setSubmitted] = useState(false);
+
+  const score = submitted ? selected.reduce((acc, val, i) => acc + (val === items[i].answer ? 1 : 0), 0) : 0;
+
+  return (
+    <div className="border rounded p-4">
+      <h3 className="font-semibold mb-2">Quick Quiz</h3>
+      {items.map((it, idx) => (
+        <div key={idx} className="mb-3">
+          <div className="mb-1">{it.q}</div>
+          <div className="flex gap-2 flex-wrap">
+            {it.choices.map((c, ci) => (
+              <button
+                key={ci}
+                onClick={() => !submitted && setSelected(s => s.map((v, i) => i === idx ? ci : v))}
+                className={`px-3 py-1 border rounded ${selected[idx]===ci ? "bg-gray-200" : ""}`}
+                aria-pressed={selected[idx]===ci}
+              >
+                {c}
+              </button>
+            ))}
+          </div>
+          {submitted && selected[idx] !== -1 && (
+            <div className="text-sm mt-1">
+              {selected[idx] === it.answer ? "✅ Correct" : `❌ Try again (Answer: ${it.choices[it.answer]})`}
+            </div>
+          )}
+        </div>
+      ))}
+      <button className="px-3 py-1 border rounded" onClick={() => setSubmitted(true)}>Check answers</button>
+      {submitted && <div className="mt-2">Score: {score} / {items.length}</div>}
+    </div>
+  );
+}

--- a/components/Phase/Orientation.tsx
+++ b/components/Phase/Orientation.tsx
@@ -1,0 +1,8 @@
+export default function Orientation({ heading, body }: { heading: string; body: string }) {
+  return (
+    <div>
+      <h2 className="text-xl font-semibold mb-1">{heading}</h2>
+      <p>{body}</p>
+    </div>
+  );
+}

--- a/components/Phase/WowPanel.tsx
+++ b/components/Phase/WowPanel.tsx
@@ -1,0 +1,8 @@
+export default function WowPanel({ heading, body }: { heading: string; body: string }) {
+  return (
+    <div className="bg-yellow-50 border-l-4 border-yellow-400 p-4 rounded">
+      <h2 className="text-xl font-semibold mb-1">{heading}</h2>
+      <p>{body}</p>
+    </div>
+  );
+}

--- a/components/Phase/Wrap.tsx
+++ b/components/Phase/Wrap.tsx
@@ -1,0 +1,10 @@
+export default function Wrap({ keyTakeaways }: { keyTakeaways: string[] }) {
+  return (
+    <div>
+      <h3 className="font-semibold">Takeaways</h3>
+      <ul className="list-disc pl-6">
+        {keyTakeaways.map((k, i) => <li key={i}>{k}</li>)}
+      </ul>
+    </div>
+  );
+}

--- a/components/Story/PhaseRenderer.tsx
+++ b/components/Story/PhaseRenderer.tsx
@@ -1,0 +1,41 @@
+import Hook from "../Phase/Hook";
+import Orientation from "../Phase/Orientation";
+import Discovery from "../Phase/Discovery";
+import WowPanel from "../Phase/WowPanel";
+import FactGems from "../Phase/FactGems";
+import MiniQuiz from "../Phase/MiniQuiz";
+import Imagine from "../Phase/Imagine";
+import Wrap from "../Phase/Wrap";
+
+export type Phase =
+  | { type: "hook"; heading: string; body: string }
+  | { type: "orientation"; heading: string; body: string }
+  | { type: "discovery"; heading: string; body: string }
+  | { type: "wow-panel"; heading: string; body: string }
+  | { type: "fact-gems"; items: { sourceId: string; text: string }[] }
+  | { type: "mini-quiz"; items: { q: string; choices: string[]; answer: number }[] }
+  | { type: "imagine"; prompt: string }
+  | { type: "wrap"; keyTakeaways: string[] };
+
+export default function PhaseRenderer({ phase }: { phase: Phase }) {
+  switch (phase.type) {
+    case "hook":
+      return <Hook {...phase} />;
+    case "orientation":
+      return <Orientation {...phase} />;
+    case "discovery":
+      return <Discovery {...phase} />;
+    case "wow-panel":
+      return <WowPanel {...phase} />;
+    case "fact-gems":
+      return <FactGems {...phase} />;
+    case "mini-quiz":
+      return <MiniQuiz {...phase} />;
+    case "imagine":
+      return <Imagine {...phase} />;
+    case "wrap":
+      return <Wrap {...phase} />;
+    default:
+      return null;
+  }
+}

--- a/components/Story/TTSButton.tsx
+++ b/components/Story/TTSButton.tsx
@@ -1,0 +1,31 @@
+"use client";
+import { useRef, useState } from "react";
+
+export default function TTSButton({ text }: { text: string }) {
+  const [speaking, setSpeaking] = useState(false);
+  const utteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
+
+  const start = () => {
+    if (!text) return;
+    stop();
+    const u = new SpeechSynthesisUtterance(text);
+    u.rate = 1.0;
+    u.onend = () => setSpeaking(false);
+    utteranceRef.current = u;
+    speechSynthesis.speak(u);
+    setSpeaking(true);
+  };
+  const pause = () => speechSynthesis.pause();
+  const resume = () => speechSynthesis.resume();
+  const stop = () => { speechSynthesis.cancel(); setSpeaking(false); };
+
+  return (
+    <div className="flex gap-2">
+      <button className="px-3 py-1 border rounded" onClick={start} aria-label="Read">Read</button>
+      <button className="px-3 py-1 border rounded" onClick={pause}>Pause</button>
+      <button className="px-3 py-1 border rounded" onClick={resume}>Resume</button>
+      <button className="px-3 py-1 border rounded" onClick={stop}>Stop</button>
+      <span className="text-xs opacity-60">{speaking ? "Speaking…" : ""}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add dedicated phase components and renderer
- Introduce interactive mini-quiz
- Provide text-to-speech "Read to me" button

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68bc923b9858832a93327f408b6995ed