### PR TITLE
feat: add readability metrics and audit

### DIFF
--- a/lib/readability.ts
+++ b/lib/readability.ts
@@ -1,0 +1,19 @@
+export function readabilityStats(text: string) {
+  const sentences = text.split(/(?<=[.!?])\s+/).filter(Boolean);
+  const words = text.split(/\s+/).filter(Boolean);
+  const syllables = words.reduce((acc, w) => acc + countSyllables(w), 0);
+  const ASL = words.length / Math.max(1, sentences.length); // average sentence length
+  const ASW = syllables / Math.max(1, words.length); // average syllables per word
+  // Flesch-Kincaid Grade Level
+  const FK = 0.39 * ASL + 11.8 * ASW - 15.59;
+  return { sentences: sentences.length, words: words.length, syllables, ASL, ASW, FK };
+}
+
+function countSyllables(word: string) {
+  const w = word.toLowerCase().replace(/[^a-z]/g, "");
+  if (!w) return 0;
+  const matches = w.match(/[aeiouy]+/g) ?? [];
+  let syl = matches.length;
+  if (w.endsWith("e")) syl = Math.max(1, syl - 1);
+  return Math.max(1, syl);
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "validate": "tsx scripts/validate-content.ts",
-    "audit": "node scripts/audit-content.js"
+    "audit": "tsx scripts/audit-content.ts"
   },
   "dependencies": {
     "next": "14.2.5",

--- a/scripts/audit-content.js
+++ b/scripts/audit-content.js
@@ -1,2 +1,0 @@
-// Placeholder for future audit script
-console.log('audit-content placeholder');

--- a/scripts/audit-content.ts
+++ b/scripts/audit-content.ts
@@ -1,0 +1,20 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { readabilityStats } from "../lib/readability";
+
+const STORIES = path.join(process.cwd(), "content", "stories");
+
+(async () => {
+  const files = (await fs.readdir(STORIES)).filter(f => f.endsWith(".json"));
+  console.log("Story Readability Audit");
+  for (const f of files) {
+    const story = JSON.parse(await fs.readFile(path.join(STORIES, f), "utf8"));
+    const narrative = (story.phases ?? [])
+      .filter((p: any) => ["hook","orientation","discovery","wow-panel","wrap"].includes(p.type))
+      .map((p: any) => [p.heading, p.body].filter(Boolean).join(". "))
+      .join(" ");
+    const stats = readabilityStats(narrative);
+    const warn = (stats.FK > 7.5 || stats.ASL > 20) ? " ⚠" : "";
+    console.log(`${story.slug}: FK=${stats.FK.toFixed(1)} ASL=${stats.ASL.toFixed(1)}${warn}`);
+  }
+})();


### PR DESCRIPTION
## Summary
- add Flesch-Kincaid readability calculation utility
- implement story audit CLI producing grade level and sentence length warnings
- wire up `npm run audit` script

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint config)*
- `npm run typecheck`
- `npm run validate`
- `npm run audit`


------
https://chatgpt.com/codex/tasks/task_e_68bca02e37c4832a925213b10cc4dd89