### PR TITLE
feat: add generation skeleton

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "validate": "tsx scripts/validate-content.ts",
-    "audit": "tsx scripts/audit-content.ts"
+    "audit": "tsx scripts/audit-content.ts",
+    "generate": "tsx scripts/generate/run-batch.ts"
   },
   "dependencies": {
     "next": "14.2.5",

--- a/scripts/generate/agents/_types.ts
+++ b/scripts/generate/agents/_types.ts
@@ -1,0 +1,39 @@
+export interface Agent<I, O> { name: string; run(input: I): Promise<O>; }
+
+export type CuratorInput = { topic: string };
+export type CuratorOutput = {
+  slug: string;
+  subAngles: string[];
+  toneTags: string[];
+  readingLevelTarget: string;
+};
+
+export type ResearchOutput = {
+  facts: { claim: string; sourceId: string; sourceName: string; url: string }[];
+  sources: { id: string; name: string; url: string }[];
+};
+export type ResearchInput = CuratorOutput;
+
+export type OutlineInput = ResearchOutput & { slug: string };
+export type OutlineOutput = {
+  phases: any[];
+  sources: { id: string; name: string; url: string }[];
+};
+
+export type StoryInput = OutlineOutput & { slug: string; topic: string };
+export type StoryDraft = { phases: any[]; title: string };
+
+export type IllustratorPromptInput = { slug: string; story: StoryDraft };
+export type IllustratorPromptOutput = { prompt: string };
+
+export type SafetyInput = { slug: string; story: StoryDraft };
+export type SafetyOutput = { ok: boolean };
+
+export type VerifierInput = { slug: string; story: StoryDraft };
+export type VerifierOutput = { verified: boolean };
+
+export type JudgeInput = { slug: string; drafts: StoryDraft[] };
+export type JudgeOutput = { chosenIndex: number; scores: number[] };
+
+export type PackagerInput = { slug: string; topic: string; draft: StoryDraft };
+export type PackagerOutput = { path: string };

--- a/scripts/generate/agents/curator.ts
+++ b/scripts/generate/agents/curator.ts
@@ -1,0 +1,18 @@
+import fs from 'node:fs/promises';
+import { Agent, CuratorInput, CuratorOutput } from './_types';
+
+export const CuratorAgent: Agent<CuratorInput, CuratorOutput> = {
+  name: 'Curator',
+  async run({ topic }) {
+    const slug = topic.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+    const output: CuratorOutput = {
+      slug,
+      subAngles: ['history', 'science', 'surprise'],
+      toneTags: ['playful', 'curious'],
+      readingLevelTarget: 'grade-6',
+    };
+    await fs.mkdir(`/tmp/${slug}`, { recursive: true });
+    await fs.writeFile(`/tmp/${slug}/curator.json`, JSON.stringify(output, null, 2), 'utf8');
+    return output;
+  },
+};

--- a/scripts/generate/agents/illustratorPrompt.ts
+++ b/scripts/generate/agents/illustratorPrompt.ts
@@ -1,0 +1,14 @@
+import fs from 'node:fs/promises';
+import { Agent, IllustratorPromptInput, IllustratorPromptOutput } from './_types';
+
+export const IllustratorPromptAgent: Agent<IllustratorPromptInput, IllustratorPromptOutput> = {
+  name: 'IllustratorPrompt',
+  async run({ slug, story }) {
+    const output: IllustratorPromptOutput = {
+      prompt: `Illustrate: ${story.title}`,
+    };
+    await fs.mkdir(`/tmp/${slug}`, { recursive: true });
+    await fs.writeFile(`/tmp/${slug}/illustratorPrompt.json`, JSON.stringify(output, null, 2), 'utf8');
+    return output;
+  },
+};

--- a/scripts/generate/agents/judge.ts
+++ b/scripts/generate/agents/judge.ts
@@ -1,0 +1,12 @@
+import fs from 'node:fs/promises';
+import { Agent, JudgeInput, JudgeOutput } from './_types';
+
+export const JudgeAgent: Agent<JudgeInput, JudgeOutput> = {
+  name: 'Judge',
+  async run({ slug, drafts }) {
+    const output: JudgeOutput = { chosenIndex: 0, scores: drafts.map(() => 1) };
+    await fs.mkdir(`/tmp/${slug}`, { recursive: true });
+    await fs.writeFile(`/tmp/${slug}/judge.json`, JSON.stringify(output, null, 2), 'utf8');
+    return output;
+  },
+};

--- a/scripts/generate/agents/outline.ts
+++ b/scripts/generate/agents/outline.ts
@@ -1,0 +1,13 @@
+import fs from 'node:fs/promises';
+import { Agent, OutlineInput, OutlineOutput } from './_types';
+
+export const OutlineAgent: Agent<OutlineInput, OutlineOutput> = {
+  name: 'Outline',
+  async run({ slug, facts, sources }) {
+    const phases = facts.map((f, i) => ({ step: i, text: f.claim }));
+    const output: OutlineOutput = { phases, sources };
+    await fs.mkdir(`/tmp/${slug}`, { recursive: true });
+    await fs.writeFile(`/tmp/${slug}/outline.json`, JSON.stringify(output, null, 2), 'utf8');
+    return output;
+  },
+};

--- a/scripts/generate/agents/packager.ts
+++ b/scripts/generate/agents/packager.ts
@@ -1,0 +1,49 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { Agent, PackagerInput, PackagerOutput } from './_types';
+
+const CONTENT_DIR = path.join(process.cwd(), 'content', 'stories');
+const TOPICS_FILE = path.join(process.cwd(), 'content', 'topics.json');
+
+export const PackagerAgent: Agent<PackagerInput, PackagerOutput> = {
+  name: 'Packager',
+  async run({ slug, topic, draft }) {
+    const story = {
+      slug,
+      title: draft.title,
+      ageBand: '10-13',
+      readingLevel: 'grade-6',
+      estReadMin: 6,
+      heroImage: { file: `/assets/${slug}/hero.webp`, alt: `${topic} hero` },
+      supportImages: [],
+      sources: [{ id: 's1', name: 'StubSource', url: 'https://example.com' }],
+      phases: draft.phases,
+      badges: [],
+      crossLinks: [],
+    };
+
+    const storyPath = path.join(CONTENT_DIR, `${slug}.json`);
+    await fs.mkdir(path.dirname(storyPath), { recursive: true });
+    await fs.writeFile(storyPath, JSON.stringify(story, null, 2), 'utf8');
+
+    const topicsArr = JSON.parse(await fs.readFile(TOPICS_FILE, 'utf8'));
+    if (!topicsArr.find((t: any) => t.slug === slug)) {
+      topicsArr.push({ slug, title: topic, thumbnail: `/assets/${slug}/hero.webp`, badges: [] });
+      await fs.writeFile(TOPICS_FILE, JSON.stringify(topicsArr, null, 2), 'utf8');
+    }
+
+    const assetDir = path.join(process.cwd(), 'public', 'assets', slug);
+    await fs.mkdir(assetDir, { recursive: true });
+    const heroPath = path.join(assetDir, 'hero.webp');
+    try {
+      await fs.access(heroPath);
+    } catch {
+      await fs.writeFile(heroPath, '');
+    }
+
+    await fs.mkdir(`/tmp/${slug}`, { recursive: true });
+    await fs.writeFile(`/tmp/${slug}/packager.json`, JSON.stringify({ storyPath }, null, 2), 'utf8');
+
+    return { path: storyPath };
+  },
+};

--- a/scripts/generate/agents/research.ts
+++ b/scripts/generate/agents/research.ts
@@ -1,0 +1,21 @@
+import fs from 'node:fs/promises';
+import { Agent, ResearchInput, ResearchOutput } from './_types';
+
+export const ResearchAgent: Agent<ResearchInput, ResearchOutput> = {
+  name: 'Research',
+  async run({ slug }) {
+    const sources = [{ id: 's1', name: 'StubSource', url: 'https://example.com' }];
+    const facts = [
+      {
+        claim: `Fact about ${slug} 1`,
+        sourceId: 's1',
+        sourceName: 'StubSource',
+        url: 'https://example.com',
+      },
+    ];
+    const output: ResearchOutput = { facts, sources };
+    await fs.mkdir(`/tmp/${slug}`, { recursive: true });
+    await fs.writeFile(`/tmp/${slug}/research.json`, JSON.stringify(output, null, 2), 'utf8');
+    return output;
+  },
+};

--- a/scripts/generate/agents/safety.ts
+++ b/scripts/generate/agents/safety.ts
@@ -1,0 +1,12 @@
+import fs from 'node:fs/promises';
+import { Agent, SafetyInput, SafetyOutput } from './_types';
+
+export const SafetyAgent: Agent<SafetyInput, SafetyOutput> = {
+  name: 'Safety',
+  async run({ slug }) {
+    const output: SafetyOutput = { ok: true };
+    await fs.mkdir(`/tmp/${slug}`, { recursive: true });
+    await fs.writeFile(`/tmp/${slug}/safety.json`, JSON.stringify(output, null, 2), 'utf8');
+    return output;
+  },
+};

--- a/scripts/generate/agents/story.ts
+++ b/scripts/generate/agents/story.ts
@@ -1,0 +1,37 @@
+import fs from 'node:fs/promises';
+import { Agent, StoryInput, StoryDraft } from './_types';
+
+export const StoryAgent: Agent<StoryInput, StoryDraft> = {
+  name: 'Story',
+  async run({ slug, topic }) {
+    const draft: StoryDraft = {
+      title: `${topic}: A Kid's Guide`,
+      phases: [
+        { type: 'hook', heading: `What if ${topic} could talk?`, body: '...' },
+        { type: 'orientation', heading: 'Where we begin', body: '...' },
+        { type: 'discovery', heading: 'Discoveries', body: '...' },
+        { type: 'wow-panel', heading: 'Big wow', body: '...' },
+        {
+          type: 'fact-gems',
+          items: [
+            { sourceId: 's1', text: 'Short fact 1.' },
+            { sourceId: 's1', text: 'Short fact 2.' },
+            { sourceId: 's1', text: 'Short fact 3.' },
+          ],
+        },
+        {
+          type: 'mini-quiz',
+          items: [
+            { q: 'Pick one', choices: ['A', 'B'], answer: 0 },
+            { q: 'Pick two', choices: ['C', 'D'], answer: 1 },
+          ],
+        },
+        { type: 'imagine', prompt: 'Imagine...' },
+        { type: 'wrap', keyTakeaways: ['A', 'B'] },
+      ],
+    };
+    await fs.mkdir(`/tmp/${slug}`, { recursive: true });
+    await fs.writeFile(`/tmp/${slug}/story.json`, JSON.stringify(draft, null, 2), 'utf8');
+    return draft;
+  },
+};

--- a/scripts/generate/agents/verifier.ts
+++ b/scripts/generate/agents/verifier.ts
@@ -1,0 +1,12 @@
+import fs from 'node:fs/promises';
+import { Agent, VerifierInput, VerifierOutput } from './_types';
+
+export const VerifierAgent: Agent<VerifierInput, VerifierOutput> = {
+  name: 'Verifier',
+  async run({ slug }) {
+    const output: VerifierOutput = { verified: true };
+    await fs.mkdir(`/tmp/${slug}`, { recursive: true });
+    await fs.writeFile(`/tmp/${slug}/verifier.json`, JSON.stringify(output, null, 2), 'utf8');
+    return output;
+  },
+};

--- a/scripts/generate/run-batch.ts
+++ b/scripts/generate/run-batch.ts
@@ -1,0 +1,66 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { CuratorAgent } from './agents/curator';
+import { ResearchAgent } from './agents/research';
+import { OutlineAgent } from './agents/outline';
+import { StoryAgent } from './agents/story';
+import { IllustratorPromptAgent } from './agents/illustratorPrompt';
+import { SafetyAgent } from './agents/safety';
+import { VerifierAgent } from './agents/verifier';
+import { JudgeAgent } from './agents/judge';
+import { PackagerAgent } from './agents/packager';
+
+const CONTENT = path.join(process.cwd(), 'content', 'stories');
+
+function log(...msg: any[]) {
+  console.log(new Date().toISOString(), ...msg);
+}
+
+async function runTopic(topic: string, force: boolean) {
+  const curator = await CuratorAgent.run({ topic });
+  const { slug } = curator;
+  const finalPath = path.join(CONTENT, `${slug}.json`);
+  if (!force) {
+    try {
+      await fs.access(finalPath);
+      log('Skip (exists):', slug);
+      return;
+    } catch {}
+  }
+
+  log('Start:', slug);
+  const research = await ResearchAgent.run(curator);
+  const outline = await OutlineAgent.run({ slug, ...research });
+  const draft = await StoryAgent.run({ slug, topic, ...outline });
+  await IllustratorPromptAgent.run({ slug, story: draft });
+  await SafetyAgent.run({ slug, story: draft });
+  await VerifierAgent.run({ slug, story: draft });
+  const judge = await JudgeAgent.run({ slug, drafts: [draft] });
+  const chosen = [draft][judge.chosenIndex];
+  await PackagerAgent.run({ slug, topic, draft: chosen });
+  log('Generated:', slug);
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const force = args.includes('--force');
+  const topicIdx = args.indexOf('--topic');
+  let topics: string[] = [];
+  if (topicIdx >= 0 && args[topicIdx + 1]) {
+    topics = [args[topicIdx + 1]];
+  } else {
+    const seed = JSON.parse(
+      await fs.readFile(path.join(process.cwd(), 'scripts/generate/topics.seed.json'), 'utf8')
+    );
+    topics = seed;
+  }
+
+  for (const topic of topics) {
+    await runTopic(topic, force);
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/generate/topics.seed.json
+++ b/scripts/generate/topics.seed.json
@@ -1,0 +1,1 @@
+["Rockets", "Deep Sea", "Volcanoes", "Ancient Egypt"]


### PR DESCRIPTION
## Summary
- scaffold multi-agent generation pipeline with shared Agent interface
- add stub agents and batch runner with idempotent story packaging
- expose `npm run generate` CLI backed by topic seed list

## Testing
- `npm run generate -- --topic "Demo Topic" --force`
- `npm run validate`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bca1d94f1c832abfa12a695ea7888d