### PR TITLE
Add OpenAI integration with client, backoff, and logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules
 .next
 out
 tsconfig.tsbuildinfo
+.env*
+!.env.example
+.ai_logs

--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ npm install
 npm run dev
 npm run build
 ```
+
+## Environment
+
+Copy `.env.example` to `.env` and fill in `OPENAI_API_KEY` for generation scripts.

--- a/lib/ai/logging.ts
+++ b/lib/ai/logging.ts
@@ -1,0 +1,17 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const LOG_DIR = path.join(process.cwd(), ".ai_logs");
+
+export async function logCall(meta: {
+  model: string;
+  temperature: number;
+  input: number;
+  output: number;
+  ms: number;
+}) {
+  await fs.mkdir(LOG_DIR, { recursive: true });
+  const file = path.join(LOG_DIR, `${new Date().toISOString().slice(0,10)}.ndjson`);
+  const record = { timestamp: new Date().toISOString(), ...meta };
+  await fs.appendFile(file, JSON.stringify(record) + "\n");
+}

--- a/lib/ai/openai.ts
+++ b/lib/ai/openai.ts
@@ -1,0 +1,40 @@
+import OpenAI from "openai";
+import { logCall } from "./logging";
+
+export const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+function sleep(ms: number) { return new Promise(r => setTimeout(r, ms)); }
+async function withBackoff<T>(fn: () => Promise<T>, max=5) {
+  let delay = 400;
+  for (let i=0;i<max;i++){
+    try { return await fn(); }
+    catch (e:any) {
+      const code = e?.status || e?.code || 0;
+      if (![429,500,502,503,504].includes(code) || i===max-1) throw e;
+      await sleep(delay + Math.random()*200);
+      delay *= 1.8;
+    }
+  }
+  // unreachable
+  throw new Error("Backoff failed");
+}
+
+export async function callResponse(args: {
+  instructions: string;
+  input: string | Array<{role:"user"|"system"|"assistant"; content:string}>;
+  temperature?: number;
+}) {
+  const start = Date.now();
+  const temperature = args.temperature ?? 0.9;
+  const inputChars = args.instructions.length + (typeof args.input === "string" ? args.input.length : args.input.reduce((n,m)=>n+m.content.length,0));
+  const res = await withBackoff(() => client.responses.create({
+    model: "gpt-4o-mini",
+    instructions: args.instructions,
+    input: typeof args.input === "string" ? [{role:"user", content: args.input}] : args.input,
+    temperature
+  }));
+  const text = (res as any).output_text ?? "";
+  const ms = Date.now() - start;
+  await logCall({ model: "gpt-4o-mini", temperature, input: inputChars, output: text.length, ms });
+  return { text, ms, raw: res };
+}

--- a/lib/ai/prompt-templates.ts
+++ b/lib/ai/prompt-templates.ts
@@ -1,0 +1,20 @@
+export const SYSTEM_STORY = `
+You write 900–1100 word educational stories for kids (ages 10–13).
+Structure exactly these phases: hook; orientation; discovery(x2–3); wow-panel; fact-gems(3); mini-quiz(2–3); imagine; wrap.
+Tone: playful yet precise. No gore/violence/scary. Keep reading level ~grade 6. Use only provided fact-gems/citations.
+`;
+
+export const SYSTEM_VERIFIER = `
+You verify factual claims. For each fact-gem, check against provided quotes/URLs. If mismatch: propose corrected sentence or drop it.
+Return a JSON diff with status per gem.
+`;
+
+export const SYSTEM_JUDGE = `
+You judge 3 story candidates with rubric: clarity/structure(40), engagement(30), factual alignment(20), quiz fit(10).
+Return JSON: { chosenIndex, scores:[...], notes }.
+`;
+
+export const SYSTEM_ART = `
+You design visual prompts for 1 hero + up to 2 support images, with concise alt-text for accessibility. Kid-safe, cohesive style.
+Return JSON with fields: hero{prompt,alt,license}, supports[].
+`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "curioquest",
       "dependencies": {
         "next": "14.2.5",
+        "openai": "^5.19.1",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "zod": "^4.1.5"
@@ -4654,6 +4655,27 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openai": {
+      "version": "5.19.1",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.19.1.tgz",
+      "integrity": "sha512-zSqnUF7oR9ksmpusKkpUgkNrj8Sl57U+OyzO8jzc7LUjTMg4DRfR3uCm+EIMA6iw06sRPNp4t7ojp3sCpEUZRQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/optionator": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "next": "14.2.5",
+    "openai": "^5.19.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "zod": "^4.1.5"

--- a/scripts/generate/smoke-ai.ts
+++ b/scripts/generate/smoke-ai.ts
@@ -1,0 +1,15 @@
+import { callResponse } from "../../lib/ai/openai";
+
+async function main() {
+  const res = await callResponse({
+    instructions: "You are a friendly assistant who replies with a short greeting.",
+    input: "Say hi to CurioQuest",
+    temperature: 0.2,
+  });
+  console.log(res.text);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- install OpenAI SDK
- add preconfigured OpenAI client with backoff and logging
- add system prompt templates and smoke script

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive setup)*
- `npm run typecheck`
- `npm run build`
- `OPENAI_API_KEY=sk-fake npx tsx scripts/generate/smoke-ai.ts` *(fails: APIConnectionError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bca64d3308832a870969da378ee239