### PR TITLE
D2: CI generate+validate+audit and release container to GHCR

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,0 +1,64 @@
+name: Generate
+
+on:
+  workflow_dispatch:
+    inputs:
+      topics:
+        description: "Comma-separated list of topics to generate"
+        required: false
+        default: ""
+      images:
+        description: "Image handling"
+        required: true
+        type: choice
+        default: skip
+        options:
+          - skip
+          - render
+          - stock
+      force:
+        description: "Force regeneration even if checkpoints exist"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Run generation
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          TOPIC_ARGS=""
+          if [ -n "${{ inputs.topics }}" ]; then
+            TOPIC_ARGS="--topic \"${{ inputs.topics }}\""
+          fi
+          FORCE_ARG=""
+          if [ "${{ inputs.force }}" = "true" ]; then
+            FORCE_ARG="--force"
+          fi
+          npm run generate -- --images=${{ inputs.images }} $FORCE_ARG $TOPIC_ARGS
+      - run: npm run validate && npm run audit
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add content public/assets
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update generated content"
+            git push
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/curioquest:latest
+            ghcr.io/${{ github.repository_owner }}/curioquest:sha-${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine AS base
+WORKDIR /app
+COPY out ./out
+RUN npm i -g serve
+ENV PORT=3000
+EXPOSE 3000
+CMD ["serve", "-s", "out", "-l", "0.0.0.0:${PORT}"]

--- a/README.md
+++ b/README.md
@@ -100,6 +100,13 @@ Topics are listed in `content/topics.json`:
 - `tsx scripts/generate/smoke-ai.ts` – quick OpenAI smoke test
 - Logs: `.ai_logs/<date>.ndjson`
 
+### CI
+
+GitHub Actions automate key workflows:
+
+- **Generate** (`.github/workflows/generate.yml`) – manually trigger to run generation, validation, and audit, committing updates to `content/` and `public/assets/`.
+- **Release** (`.github/workflows/release.yml`) – on push to `main` or manual dispatch, builds the static site and publishes a container image to GHCR that serves `out/` on `$PORT`.
+
 ## Generation Pipeline (Agents)
 1. **Curator** – derives slug, sub‑angles, tone
 2. **Research** – gathers facts and sources (Wikipedia, NASA)


### PR DESCRIPTION
## Summary
- add generate workflow to run content generation, validation, and audit and commit results
- add release workflow to build static site and publish container images to GHCR
- add Dockerfile using `serve` to expose static `out/` on `$PORT`
- document CI workflows in README

## Testing
- `npm ci --legacy-peer-deps`
- `npm test` (fails: Missing script "test")
- `npm run lint` (aborted interactive setup)
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bcb8932de4832aa47e8ef10a9da97d