### PR TITLE
Fix review slug build export

### DIFF
--- a/app/(admin)/review/[slug]/page.tsx
+++ b/app/(admin)/review/[slug]/page.tsx
@@ -10,12 +10,14 @@ export const dynamicParams = false;
 
 export const dynamic = "force-static";
 
-export async function generateStaticParams(): Promise<{ slug: string }[]> {
+export async function generateStaticParams() {
   try {
     const entries = await fs.readdir(INCOMING_DIR, { withFileTypes: true });
-    return entries.filter(e => e.isDirectory()).map(e => ({ slug: e.name }));
+    const slugs = entries.filter((e) => e.isDirectory()).map((e) => ({ slug: e.name }));
+    // Next.js static export requires at least one path for dynamic routes
+    return slugs.length > 0 ? slugs : [{ slug: "__placeholder__" }];
   } catch {
-    return [];
+    return [{ slug: "__placeholder__" }];
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure `/review/[slug]` exports with placeholder static params when no incoming stories

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (prompts for ESLint config)
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd6bed6b48832a83343c28c9f66372