### PR TITLE
fix(generate): robust topic parsing with consistent slug/asset paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "curioquest",
       "dependencies": {
+        "mri": "^1.2.0",
         "next": "14.2.5",
         "openai": "^5.19.1",
         "react": "18.3.1",
@@ -5632,6 +5633,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "publish": "tsx scripts/review/publish.ts --slug"
   },
   "dependencies": {
+    "mri": "^1.2.0",
     "next": "14.2.5",
     "openai": "^5.19.1",
     "react": "18.3.1",

--- a/scripts/generate/agents/_types.ts
+++ b/scripts/generate/agents/_types.ts
@@ -1,6 +1,6 @@
 export interface Agent<I, O> { name: string; run(input: I): Promise<O>; }
 
-export type CuratorInput = { topic: string };
+export type CuratorInput = { topic: string; slug: string };
 export type CuratorOutput = {
   slug: string;
   subAngles: string[];

--- a/scripts/generate/agents/curator.ts
+++ b/scripts/generate/agents/curator.ts
@@ -3,8 +3,7 @@ import { Agent, CuratorInput, CuratorOutput } from './_types';
 
 export const CuratorAgent: Agent<CuratorInput, CuratorOutput> = {
   name: 'Curator',
-  async run({ topic }) {
-    const slug = topic.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+  async run({ topic, slug }) {
     const output: CuratorOutput = {
       slug,
       subAngles: ['history', 'science', 'surprise'],


### PR DESCRIPTION
## Summary
- use `mri` for argument parsing in `run-batch.ts`
- support comma-separated or repeated `--topic` flags and trim quotes
- derive a single `slug` per topic and pass it through all agents and asset paths
- add `mri` dependency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*
- `npm run typecheck`
- `npm run generate -- --topic Rockets --topic "Deep Sea" --topic Volcanoes --max-ms-per-topic=1 --images=skip`

------
https://chatgpt.com/codex/tasks/task_e_68bd7360cb90832a820fdb10b9747cd4