### PR TITLE
Add health check endpoint and port docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Stories target grades 5–7 with inclusive language and clear structure. Each ph
 ## Deployment
 `npm run build` outputs a fully static site in `out/`. Deploy with Vercel, Cloudflare Pages, Netlify, or any static file host. No server is required.
 
+For container deployments (e.g. Runpod), start `node serverless.mjs` after building. The app serves static files on `process.env.PORT` and a `/ping` health check on `process.env.PORT_HEALTH` for the load balancer.
+
 ## Roadmap
 - Search across stories
 - Recommendation engine

--- a/serverless.mjs
+++ b/serverless.mjs
@@ -9,6 +9,12 @@ const outDir = path.join(__dirname, 'out');
 
 const app = express();
 
+const pingHandler = (_req, res) => {
+  res.sendStatus(200);
+};
+
+app.get('/ping', pingHandler);
+
 // Serve exported static files
 app.use(express.static(outDir));
 
@@ -19,6 +25,15 @@ app.get('*', (_req, res) => {
 
 // Export handler expected by Runpod serverless
 export const handler = serverless(app);
+
+// Health check server for Runpod
+if (process.env.PORT_HEALTH) {
+  const healthApp = express();
+  healthApp.get('/ping', pingHandler);
+  healthApp.listen(process.env.PORT_HEALTH, () => {
+    console.log(`Health server running on port ${process.env.PORT_HEALTH}`);
+  });
+}
 
 // Allow local testing
 if (process.env.RUNPOD_LOCAL) {


### PR DESCRIPTION
## Summary
- add `/ping` route and dedicated health server on `PORT_HEALTH`
- document `PORT` and `PORT_HEALTH` usage for container deployments

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68bde3a5f230832ab2a42c2e0df0a5a9