### PR TITLE
docs: clarify RunPod API key usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,35 @@ Stories target grades 5–7 with inclusive language and clear structure. Each ph
 ## Deployment
 `npm run build` outputs a fully static site in `out/`. Deploy with Vercel, Cloudflare Pages, Netlify, or any static file host. No server is required.
 
+### RunPod Serverless
+When deploying to [RunPod](https://www.runpod.io/) you will receive two identifiers:
+
+- **Endpoint ID** – a UUID shown in the endpoint URL.
+- **API Key** – your personal secret used for authentication.
+
+The API key is **different** from the endpoint ID. You can create or view API keys in the RunPod dashboard by clicking your avatar → **API Keys**.
+
+Example requests:
+
+Using an Authorization header:
+
+```bash
+curl -X POST https://api.runpod.ai/v2/<ENDPOINT_ID>/run \
+  -H "Authorization: Bearer <RUNPOD_API_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{"input": {}}'
+```
+
+Passing the key as a query parameter:
+
+```bash
+curl "https://api.runpod.ai/v2/<ENDPOINT_ID>/run?api_key=<RUNPOD_API_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{"input": {}}'
+```
+
+Use your API key in these requests, not the endpoint ID.
+
 ## Roadmap
 - Search across stories
 - Recommendation engine


### PR DESCRIPTION
## Summary
- explain difference between RunPod endpoint ID and API key
- document where to find API keys in the RunPod dashboard
- provide curl examples with Authorization header and `api_key` query parameter

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(prompts for configuration and exits)*

------
https://chatgpt.com/codex/tasks/task_e_68bde3a89778832aa3eb799ca4eb8c25