### PR TITLE
chore: replace deprecated next export

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "export": "next build && next export",
+    "export": "next build",
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary
- replace `next export` command with `next build`

## Testing
- `npm run lint` *(fails: interactive ESLint setup prompt)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68beaf8d8cbc832aaf65deef53c36423