### PR TITLE
Fix topic skipping and StoryAgent JSON parsing

### DIFF
--- a/scripts/generate/run-batch.ts
+++ b/scripts/generate/run-batch.ts
@@ -262,9 +262,13 @@ async function main() {
   } catch {}
   const checkpointSet = new Set(checkpoint);
 
+  const hasExplicitTopics = topicFlags.length > 0;
+
   const records: RecordEntry[] = topics.map((t) => ({
     topic: t,
-    status: !force && !all && checkpointSet.has(t) ? 'skipped' : 'pending',
+    status: !force && !all && !hasExplicitTopics && checkpointSet.has(t)
+      ? 'skipped'
+      : 'pending',
   }));
 
   const topicsToRun = records.filter((r) => r.status === 'pending');


### PR DESCRIPTION
## Summary
- Prevent run-batch from skipping explicitly requested topics by ignoring checkpoints when specific topics are passed
- Make StoryAgent resilient to malformed AI responses by adding a fallback draft and JSON parsing safeguards

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive config)*
- `npm run typecheck` *(fails: Cannot find module 'uuid')*


------
https://chatgpt.com/codex/tasks/task_e_68bebd81f964832a9f9d0bb939614a57