### PR TITLE
fix: handle packaging failures and enable forced parallel generation

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -31,9 +31,9 @@ jobs:
         run: |
           TOPICS="${{ github.event.inputs.topics }}"
           if [ -n "$TOPICS" ]; then
-            npm run generate -- --images=render --topic "$TOPICS" --review-mode=off
+            npm run generate -- --images=render --topic "$TOPICS" --review-mode=off --force --concurrency=5
           else
-            npm run generate -- --images=render --all --review-mode=off
+            npm run generate -- --images=render --all --review-mode=off --force --concurrency=5
           fi
       - name: List generated files
         run: |

--- a/scripts/generate/agents/_types.ts
+++ b/scripts/generate/agents/_types.ts
@@ -48,4 +48,4 @@ export type PackagerInput = {
   };
   reviewMode?: boolean;
 };
-export type PackagerOutput = { path: string };
+export type PackagerOutput = { path: string; ok: boolean };

--- a/scripts/generate/agents/packager.ts
+++ b/scripts/generate/agents/packager.ts
@@ -29,7 +29,7 @@ export const PackagerAgent: Agent<PackagerInput, PackagerOutput> = {
       const rej = path.join(process.cwd(), '_rejects', `${slug}-${uuid()}.json`);
       await fs.mkdir(path.dirname(rej), { recursive: true });
       await fs.writeFile(rej, JSON.stringify({ story, errors: parsed.error.format() }, null, 2), 'utf8');
-      return { path: rej };
+      return { path: rej, ok: false };
     }
 
     let storyPath: string;
@@ -67,6 +67,6 @@ export const PackagerAgent: Agent<PackagerInput, PackagerOutput> = {
     await fs.mkdir(`/tmp/${slug}`, { recursive: true });
     await fs.writeFile(`/tmp/${slug}/packager.json`, JSON.stringify({ storyPath }, null, 2), 'utf8');
 
-    return { path: storyPath };
+    return { path: storyPath, ok: true };
   },
 };

--- a/scripts/generate/run-batch.ts
+++ b/scripts/generate/run-batch.ts
@@ -181,7 +181,7 @@ async function runTopic(
   }
 
   const packagerStart = Date.now();
-  await PackagerAgent.run({
+  const packaged = await PackagerAgent.run({
     slug,
     topic,
     draft: finalDraft,
@@ -190,6 +190,14 @@ async function runTopic(
     reviewMode,
   });
   timings.PackagerAgent = Date.now() - packagerStart;
+
+  if (!packaged.ok) {
+    try {
+      await fs.rm(assetDir, { recursive: true, force: true });
+    } catch {}
+    log('Packager rejected:', slug);
+    return { status: 'error', slug, ms: Date.now() - start, tokensIn: tokensOut, tokensOut, timings };
+  }
 
   log('Generated:', slug);
 


### PR DESCRIPTION
## Summary
- ensure packager reports failures and clean up asset folders on reject
- run GitHub generator with forced regeneration and higher concurrency
- expose `ok` flag in Packager output for reliable workflow status

## Testing
- `npm run lint` *(fails: Next.js ESLint requires interactive setup)*
- `npm run typecheck` *(fails: Cannot find module 'uuid'; Set iteration requires higher target)*

------
https://chatgpt.com/codex/tasks/task_e_68bec3acbe88832a9dc6345119b8480a