### PR TITLE
Ensure clean regeneration and image rendering

### DIFF
--- a/scripts/generate/imageRender.ts
+++ b/scripts/generate/imageRender.ts
@@ -19,13 +19,15 @@ export async function saveBase64Webp(b64: string, outFile: string) {
   await sharp(buf).webp({ quality: 82 }).toFile(outFile);
 }
 
-export async function renderImage(prompt: string, outFile: string) {
+export async function renderImage(prompt: string, outFile: string, force = false) {
   const cli = await loadClient();
   if (!cli) return false;
-  try {
-    await fs.access(outFile);
-    return true;
-  } catch {}
+  if (!force) {
+    try {
+      await fs.access(outFile);
+      return true;
+    } catch {}
+  }
   const res = await cli.images.generate({ model: 'gpt-image-1', prompt, size: '1024x1024' });
   const b64 = res?.data?.[0]?.b64_json;
   if (!b64) return false;


### PR DESCRIPTION
## Summary
- Allow `--force` runs to remove previous story content and assets for a clean regeneration
- Pass force flag through image rendering so OpenAI images are regenerated
- Clear checkpoints for forced topics before running to avoid stale skips

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next lint requires interactive setup)*
- `npm run typecheck` *(fails: Cannot find module 'uuid' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68bec7dcaaf8832a80cfeb7c543466aa