### PR TITLE
fix: use supported gpt image model

### DIFF
--- a/scripts/generate/imageRender.ts
+++ b/scripts/generate/imageRender.ts
@@ -32,7 +32,7 @@ export async function renderImage(prompt: string, outFile: string, force = false
     } catch {}
   }
   try {
-    const res = await cli.images.generate({ model: 'gpt-image-1.5', prompt, size: '1024x1024' });
+    const res = await cli.images.generate({ model: 'gpt-image-1', prompt, size: '1024x1024' });
     const b64 = res?.data?.[0]?.b64_json;
     if (!b64) {
       console.warn('Image generation returned no data');


### PR DESCRIPTION
## Summary
- use supported `gpt-image-1` model in `renderImage`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires manual ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68bee01fd7b8832aaa18daf58e77b30a