### PR TITLE
feat: clean generation and enrich stories

### DIFF
--- a/scripts/generate/agents/story.ts
+++ b/scripts/generate/agents/story.ts
@@ -20,22 +20,46 @@ function makeFallbackDraft(topic: string, factGems: StoryInput['factGems']): Sto
   return {
     title: `${topic} Basics`,
     phases: [
-      { type: 'hook', heading: `Exploring ${topic}`, body: `Let's learn about ${topic}.` },
-      { type: 'orientation', heading: `What are ${topic}?`, body: `${topic} in a nutshell.` },
-      { type: 'discovery', heading: `Digging into ${topic}`, body: `More about ${topic}.` },
-      { type: 'wow-panel', heading: `A wow moment`, body: `${topic} can be surprising!` },
+      {
+        type: 'hook',
+        heading: `Exploring ${topic}`,
+        body: `Let's learn about ${topic}. This topic touches our everyday lives in ways we might not notice. From the moment we wake up until we go to sleep, ${topic} play a role in our world.`,
+      },
+      {
+        type: 'orientation',
+        heading: `What are ${topic}?`,
+        body: `${topic} in a nutshell. Understanding the basics of ${topic} helps us appreciate how they work and why they matter. With a little curiosity, we can uncover stories hidden in history, science, and art about ${topic}.`,
+      },
+      {
+        type: 'discovery',
+        heading: `Digging into ${topic}`,
+        body: `More about ${topic}. Imagine walking through a museum, visiting a lab, or exploring outdoors—each place offers clues about ${topic}. The more we investigate, the more connections we find to technology, culture, and the natural world.`,
+      },
+      {
+        type: 'wow-panel',
+        heading: `A wow moment`,
+        body: `${topic} can be surprising! Sometimes a single fact can change how we think about the entire subject, showing just how remarkable ${topic} truly are.`,
+      },
       { type: 'fact-gems', items: factGems.slice(0, 3) },
       {
         type: 'mini-quiz',
         items: [
           { q: `Where do ${topic} travel?`, choices: ['Space', 'Sea'], answer: 0 },
           { q: `Are ${topic} fast?`, choices: ['Yes', 'No'], answer: 0 },
+          { q: `Would you like to explore ${topic}?`, choices: ['Absolutely', 'Maybe later'], answer: 0 },
         ],
       },
-      { type: 'imagine', prompt: `Imagine using ${topic} for adventure.` },
+      {
+        type: 'imagine',
+        prompt: `Imagine using ${topic} for adventure. Picture yourself sharing amazing facts with friends or building a project inspired by ${topic}.`,
+      },
       {
         type: 'wrap',
-        keyTakeaways: [`${topic} are fascinating`, `Learning about ${topic} is fun`],
+        keyTakeaways: [
+          `${topic} are fascinating`,
+          `Learning about ${topic} is fun`,
+          `There is always more to discover about ${topic}`,
+        ],
       },
     ],
   };

--- a/scripts/generate/run-batch.ts
+++ b/scripts/generate/run-batch.ts
@@ -240,14 +240,14 @@ async function main() {
   const argv = mri(process.argv.slice(2), {
     string: ['topic', 'images', 'concurrency', 'max-ms-per-topic', 'max-chars'],
     boolean: ['force', 'review-mode', 'clean'],
-    default: { images: 'render', concurrency: '10', 'review-mode': false },
+    default: { images: 'render', concurrency: '20', 'review-mode': false, clean: true },
   });
 
   const force = !!argv.force;
   const all = !!argv.all;
-  const clean = !!argv.clean;
+  const clean = argv.clean as boolean;
   const imageMode = argv.images as ImageMode;
-  const concurrency = parseInt(argv.concurrency || '10', 10);
+  const concurrency = parseInt(argv.concurrency || '20', 10);
   const maxMsPerTopic = argv['max-ms-per-topic']
     ? parseInt(argv['max-ms-per-topic'], 10)
     : Infinity;
@@ -263,6 +263,11 @@ async function main() {
       fs.rm(path.join(process.cwd(), '_rejects'), { recursive: true, force: true }),
       fs.rm(path.join(process.cwd(), 'review', 'incoming'), { recursive: true, force: true }),
       fs.rm(CHECKPOINT_FILE, { force: true }),
+    ]);
+    await Promise.all([
+      fs.mkdir(path.join(process.cwd(), 'content', 'stories'), { recursive: true }),
+      fs.mkdir(path.join(process.cwd(), 'public', 'assets'), { recursive: true }),
+      fs.mkdir(path.join(process.cwd(), 'review', 'incoming'), { recursive: true }),
     ]);
     try {
       await fs.writeFile(path.join(process.cwd(), 'content', 'topics.json'), '[]', 'utf8');


### PR DESCRIPTION
## Summary
- default batch runner concurrency to 20 and automatically clean old content before generating
- expand fallback story drafts with more detailed phases and quizzes

## Testing
- `npm run lint` *(fails: interactive ESLint setup)*
- `npm run typecheck`
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68bef44ccb6c832abc730a32aba54ba7