### PR TITLE
fix: allow empty topics

### DIFF
--- a/schemas/topics.ts
+++ b/schemas/topics.ts
@@ -7,6 +7,6 @@ export const TopicSchema = z.object({
   badges: z.array(z.string()).optional(),
 });
 
-export const TopicsSchema = z.array(TopicSchema).min(1);
+export const TopicsSchema = z.array(TopicSchema);
 
 export type Topic = z.infer<typeof TopicSchema>;


### PR DESCRIPTION
## Summary
- allow validating content when the topics list is empty to support single-topic workflows

## Testing
- `npm run validate -- --strict && npm run audit && npm run cleanup`


------
https://chatgpt.com/codex/tasks/task_e_68bef69286fc832aac1ac63fa9ab2d3c