### PR TITLE
fix: retain generated topics in repository

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -31,9 +31,9 @@ jobs:
         run: |
           TOPICS="${{ github.event.inputs.topics }}"
           if [ -n "$TOPICS" ]; then
-            npm run generate -- --images=render --topic "$TOPICS" --review-mode=off --force --concurrency=5
+            npm run generate -- --images=render --topic "$TOPICS" --review-mode=off --force --clean=false --concurrency=5
           else
-            npm run generate -- --images=render --all --review-mode=off --force --concurrency=5
+            npm run generate -- --images=render --all --review-mode=off --force --clean=false --concurrency=5
           fi
       - name: List generated files
         run: |


### PR DESCRIPTION
## Summary
- prevent generate workflow from wiping existing topics during new runs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68bf08028490832ab30386b2db477a63